### PR TITLE
Fix build warnings

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -46,29 +46,30 @@
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <version>4.10</version>
+            <version>4.12</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>com.googlecode.json-simple</groupId>
             <artifactId>json-simple</artifactId>
-            <version>1.1</version>
+            <version>1.1.1</version>
         </dependency>
         <dependency>
             <groupId>org.apache.httpcomponents</groupId>
             <artifactId>httpclient</artifactId>
-            <version>4.3.1</version>
+            <version>4.5</version>
         </dependency>
         <dependency>
             <groupId>org.json</groupId>
             <artifactId>json</artifactId>
-            <version>20090211</version>
+            <version>20141113</version>
         </dependency>
     </dependencies>
     <build>
         <plugins>
             <plugin>
                 <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.3</version>
                 <configuration>
                     <source>1.5</source>
                     <target>1.5</target>
@@ -77,23 +78,24 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-release-plugin</artifactId>
-                <version>2.0</version>
+                <version>2.5.2</version>
                 <dependencies>
                     <dependency>
                         <groupId>org.apache.maven.scm</groupId>
                         <artifactId>maven-scm-provider-gitexe</artifactId>
-                        <version>1.2</version>
+                        <version>1.9.4</version>
                     </dependency>
                 </dependencies>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-scm-plugin</artifactId>
-                <version>1.3</version>
+                <version>1.9.4</version>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-gpg-plugin</artifactId>
+                <version>1.6</version>
                 <executions>
                     <execution>
                         <id>sign-artifacts</id>

--- a/src/main/java/com/saucelabs/saucerest/SauceREST.java
+++ b/src/main/java/com/saucelabs/saucerest/SauceREST.java
@@ -671,7 +671,7 @@ public class SauceREST {
     /**
      * Returns a String (in JSON format) representing the list of objects describing all the OS and browser platforms
      * currently supported on Sauce Labs.
-     *
+     * (see <a href="https://docs.saucelabs.com/reference/rest-api/#get-supported-platforms">https://docs.saucelabs.com/reference/rest-api/#get-supported-platforms</a>).
      * @param automationApi the automation API name
      * @return String (in JSON format) representing the supported platforms information
      */

--- a/src/main/java/com/saucelabs/saucerest/SauceREST.java
+++ b/src/main/java/com/saucelabs/saucerest/SauceREST.java
@@ -20,7 +20,6 @@ import org.apache.http.protocol.HttpContext;
 import org.json.JSONException;
 import org.json.JSONObject;
 import org.json.simple.JSONValue;
-import sun.misc.BASE64Encoder;
 
 import javax.net.ssl.HttpsURLConnection;
 import java.io.*;
@@ -38,6 +37,7 @@ import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import javax.xml.bind.DatatypeConverter;
 
 /**
  * Simple Java API that invokes the Sauce REST API.  The full list of the Sauce REST API functionality is available from
@@ -517,14 +517,7 @@ public class SauceREST {
      */
     protected String encodeAuthentication() {
         String auth = username + ":" + accessKey;
-        //Handle long strings encoded using BASE64Encoder - see http://bugs.sun.com/bugdatabase/view_bug.do?bug_id=6947917
-        BASE64Encoder encoder = new BASE64Encoder() {
-            @Override
-            protected int bytesPerLine() {
-                return 9999;
-            }
-        };
-        auth = "Basic " + new String(encoder.encode(auth.getBytes()));
+        auth = "Basic " + DatatypeConverter.printBase64Binary(auth.getBytes());
         return auth;
     }
 


### PR DESCRIPTION
* Update all dependencies version
* Fix warning "BASE64Encoder is internal proprietary API and may be removed in a future release". I remove sun.misc.BASE64Encoder library, but after that lost Java 1.5 support.