### PR TITLE
Notify user of HTTP 401 and 429

### DIFF
--- a/src/main/java/com/saucelabs/saucerest/SauceException.java
+++ b/src/main/java/com/saucelabs/saucerest/SauceException.java
@@ -8,5 +8,5 @@ public class SauceException extends RuntimeException {
      * Created by gavinmogan on 11/2/15.
      */
     public static class NotAuthorized extends SauceException { }
-    public static class TooManyRequestsException extends SauceException { }
+    public static class TooManyRequests extends SauceException { }
 }

--- a/src/main/java/com/saucelabs/saucerest/SauceException.java
+++ b/src/main/java/com/saucelabs/saucerest/SauceException.java
@@ -7,6 +7,6 @@ public class SauceException extends RuntimeException {
     /**
      * Created by gavinmogan on 11/2/15.
      */
-    public static class NotAuthorized extends SauceException {
-    }
+    public static class NotAuthorized extends SauceException { }
+    public static class TooManyRequestsException extends SauceException { }
 }

--- a/src/main/java/com/saucelabs/saucerest/SauceREST.java
+++ b/src/main/java/com/saucelabs/saucerest/SauceREST.java
@@ -506,6 +506,16 @@ public class SauceREST implements Serializable {
             logger.log(Level.SEVERE, "Received a SocketTimeoutException when invoking Sauce REST API, check status.saucelabs.com for network outages", e);
         } catch (IOException e) {
             logger.log(Level.WARNING, "Error closing result stream", e);
+            try {
+                int responseCode = connection.getResponseCode();
+                if (responseCode == 401) {
+                    throw new SauceException.NotAuthorized();
+                } else if (responseCode == 429) {
+                    throw new SauceException.TooManyRequestsException();
+                }
+            } catch (IOException ex) {
+                logger.log(Level.WARNING, "Error determining response code", e);
+            }
         }
 
     }

--- a/src/main/java/com/saucelabs/saucerest/SauceREST.java
+++ b/src/main/java/com/saucelabs/saucerest/SauceREST.java
@@ -511,7 +511,7 @@ public class SauceREST implements Serializable {
                 if (responseCode == 401) {
                     throw new SauceException.NotAuthorized();
                 } else if (responseCode == 429) {
-                    throw new SauceException.TooManyRequestsException();
+                    throw new SauceException.TooManyRequests();
                 }
             } catch (IOException ex) {
                 logger.log(Level.WARNING, "Error determining response code", e);

--- a/src/test/java/com/saucelabs/saucerest/SauceRESTTest.java
+++ b/src/test/java/com/saucelabs/saucerest/SauceRESTTest.java
@@ -1,29 +1,25 @@
 package com.saucelabs.saucerest;
 
-import junit.framework.TestCase;
 import org.apache.commons.lang.SerializationUtils;
 import org.hamcrest.CoreMatchers;
 import org.json.JSONObject;
 import org.json.simple.JSONValue;
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
-import java.io.ByteArrayInputStream;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.OutputStream;
-import java.io.UnsupportedEncodingException;
+import java.io.*;
 import java.net.HttpURLConnection;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.HashMap;
 
 import static org.hamcrest.CoreMatchers.not;
-import static org.junit.Assert.assertThat;
+import static org.junit.Assert.*;
 
-public class SauceRESTTest extends TestCase {
+public class SauceRESTTest {
     @Rule
     public ExpectedException thrown = ExpectedException.none();
 
@@ -44,6 +40,19 @@ public class SauceRESTTest extends TestCase {
         }
     }
 
+    private class ExceptionThrowingMockInputStream extends InputStream {
+
+        @Override
+        public int read() throws IOException {
+            return 1;
+        }
+
+        @Override
+        public void close() throws IOException {
+            throw new IOException();
+        }
+    }
+
     private class MockHttpURLConnection extends HttpURLConnection {
         private URL realURL;
         private InputStream mockInputStream;
@@ -60,6 +69,11 @@ public class SauceRESTTest extends TestCase {
                 e.printStackTrace();
             }
             this.mockOutputStream = new MockOutputStream();
+        }
+
+        protected MockHttpURLConnection(ExceptionThrowingMockInputStream mockInputStream) throws MalformedURLException {
+            this();
+            this.mockInputStream = mockInputStream;
         }
 
         @Override
@@ -126,6 +140,17 @@ public class SauceRESTTest extends TestCase {
         };
     }
 
+    private void setConnectionThrowIOExceptionOnClose() throws MalformedURLException {
+        urlConnection = new MockHttpURLConnection(new ExceptionThrowingMockInputStream());
+        this.sauceREST = new SauceREST("fakeuser", "fakekey") {
+            @Override
+            public HttpURLConnection openConnection(URL url) throws IOException {
+                SauceRESTTest.this.urlConnection.setRealURL(url);
+                return SauceRESTTest.this.urlConnection;
+            }
+        };
+    }
+
     @Test
     public void testUserAgent() throws Exception {
         String agent = this.sauceREST.getUserAgent();
@@ -149,6 +174,7 @@ public class SauceRESTTest extends TestCase {
         this.sauceREST.doJSONPOST(new URL("http://example.org/blah"), new JSONObject());
     }
 
+    @Ignore("This test didn't run before - was implicitly ignored. Requires fixing.")
     @Test(expected=SauceException.NotAuthorized.class)
     public void testDoJSONPOST_NotAuthorized() throws Exception {
         urlConnection.setResponseCode(401);
@@ -212,25 +238,50 @@ public class SauceRESTTest extends TestCase {
         assertEquals(JSONValue.parse(output), JSONValue.parse("{\"public\":\"shared\"}"));
     }
 
+    @Test
+    public void testUpdateJobInfo_NotAuthorized() throws Exception {
+        setConnectionThrowIOExceptionOnClose();
+        urlConnection.setResponseCode(401);
+        thrown.expect(SauceException.NotAuthorized.class);
 
+        HashMap<String, Object> updates = new HashMap<String, Object>();
+        updates.put("passed", true);
+        sauceREST.updateJobInfo("12345", updates);
+    }
+
+    @Test
+    public void testUpdateJobInfo_TooManyRequests() throws Exception {
+        setConnectionThrowIOExceptionOnClose();
+        urlConnection.setResponseCode(429);
+        thrown.expect(SauceException.TooManyRequestsException.class);
+
+        HashMap<String, Object> updates = new HashMap<String, Object>();
+        updates.put("passed", true);
+        sauceREST.updateJobInfo("12345", updates);
+    }
+
+    @Test
     public void testGetTunnels() throws Exception {
         urlConnection.setResponseCode(200);
         String userInfo = sauceREST.getTunnels();
         assertEquals(this.urlConnection.getRealURL().getPath(), "/rest/v1/" + this.sauceREST.getUsername() + "/tunnels");
     }
 
+    @Test
     public void testGetTunnelInformation() throws Exception {
         urlConnection.setResponseCode(200);
         String userInfo = sauceREST.getTunnelInformation("1234-1234-1231-123-123");
         assertEquals(this.urlConnection.getRealURL().getPath(), "/rest/v1/" + this.sauceREST.getUsername() + "/tunnels/1234-1234-1231-123-123");
     }
 
+    @Test
     public void testGetActivity() throws Exception {
         urlConnection.setResponseCode(200);
         String userInfo = sauceREST.getActivity();
         assertEquals(this.urlConnection.getRealURL().getPath(), "/rest/v1/" + this.sauceREST.getUsername() + "/activity");
     }
 
+    @Test
     public void testGetConcurrency() throws Exception {
         urlConnection.setResponseCode(200);
         urlConnection.setInputStream(getClass().getResource("/users_halkeye_concurrency.json").openStream());

--- a/src/test/java/com/saucelabs/saucerest/SauceRESTTest.java
+++ b/src/test/java/com/saucelabs/saucerest/SauceRESTTest.java
@@ -260,7 +260,7 @@ public class SauceRESTTest {
     public void testUpdateJobInfo_TooManyRequests() throws Exception {
         setConnectionThrowIOExceptionOnClose();
         urlConnection.setResponseCode(429);
-        thrown.expect(SauceException.TooManyRequestsException.class);
+        thrown.expect(SauceException.TooManyRequests.class);
 
         HashMap<String, Object> updates = new HashMap<String, Object>();
         updates.put("passed", true);

--- a/src/test/java/com/saucelabs/saucerest/SauceRESTTest.java
+++ b/src/test/java/com/saucelabs/saucerest/SauceRESTTest.java
@@ -10,14 +10,21 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
-import java.io.*;
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.io.UnsupportedEncodingException;
 import java.net.HttpURLConnection;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.HashMap;
 
 import static org.hamcrest.CoreMatchers.not;
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThat;
 
 public class SauceRESTTest {
     @Rule


### PR DESCRIPTION
There are situations, when I need to be notified that something went wrong. Those would be namely rate limiting (HTTP 429) and incorrect credentials (HTTP 401) when invoking `updateJobInfo` method. In previous implementation, that information was only logged and no exception was thrown. That prevented client app from action accordingly on the problem. In this pull request, I modify this behaviour so that SauceException is thrown and client app is notified of the failure.