### PR TITLE
Remove oraclejdk7 from travis-ci config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,6 @@ before_script:
 install: mvn install -DskipTests=true -Dgpg.skip=true -B -V
 jdk:
   - oraclejdk8
-  - oraclejdk7
   - openjdk7
 after_success:
   - codecov


### PR DESCRIPTION
travis-ci/travis-ci#7964 (comment):
"oraclejdk7 is unfortunately no longer available in Trusty after our latest updates, since we can no longer support oraclejdk7 on our recent build images due to Oracle's withdrawal. See: http://www.webupd8.org/2017/06/why-oracle-java-7-and-6-installers-no.html

If this is an option for you, I'd recommend switching to jdk: openjdk7, which is available in the new Trusty images."