### PR TITLE
Change source and target compilation levels to Java 7

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -133,8 +133,8 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.3</version>
                 <configuration>
-                    <source>1.5</source>
-                    <target>1.5</target>
+                    <source>1.7</source>
+                    <target>1.7</target>
                 </configuration>
             </plugin>
             <plugin>


### PR DESCRIPTION
`com.saucelabs.saucerest.SauceREST` uses `java.util.Objects` API ([L31](https://github.com/saucelabs/saucerest-java/blob/master/src/main/java/com/saucelabs/saucerest/SauceREST.java#L31), [L828-L831](https://github.com/saucelabs/saucerest-java/blob/master/src/main/java/com/saucelabs/saucerest/SauceREST.java#L828-L831)), which is available starting from Java 7 only, so default compilation level should be increased from 5 to 7

