### PR TITLE
Use org.json:json library for all JSON operations

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -55,11 +55,6 @@
     </distributionManagement>
     <dependencies>
         <dependency>
-            <groupId>com.googlecode.json-simple</groupId>
-            <artifactId>json-simple</artifactId>
-            <version>1.1.1</version>
-        </dependency>
-        <dependency>
             <groupId>org.apache.httpcomponents</groupId>
             <artifactId>httpclient</artifactId>
             <version>4.5.5</version>

--- a/src/main/java/com/saucelabs/saucerest/SauceREST.java
+++ b/src/main/java/com/saucelabs/saucerest/SauceREST.java
@@ -3,7 +3,6 @@ package com.saucelabs.saucerest;
 import org.apache.commons.codec.binary.Base64;
 import org.json.JSONException;
 import org.json.JSONObject;
-import org.json.simple.JSONValue;
 
 import javax.net.ssl.HttpsURLConnection;
 import java.io.BufferedInputStream;
@@ -154,8 +153,7 @@ public class SauceREST implements Serializable {
             postBack.setRequestProperty("Content-Type", "application/json");
             addAuthenticationProperty(postBack);
 
-            String jsonText = JSONValue.toJSONString(body);
-            postBack.getOutputStream().write(jsonText.getBytes());
+            postBack.getOutputStream().write(body.toString().getBytes());
 
             reader = new BufferedReader(new InputStreamReader(postBack.getInputStream()));
 
@@ -439,8 +437,7 @@ public class SauceREST implements Serializable {
             postBack.setDoOutput(true);
             postBack.setRequestMethod("PUT");
             addAuthenticationProperty(postBack);
-            String jsonText = JSONValue.toJSONString(updates);
-            postBack.getOutputStream().write(jsonText.getBytes());
+            postBack.getOutputStream().write(new JSONObject(updates).toString().getBytes());
         } catch (IOException e) {
             logger.log(Level.WARNING, "Error updating Sauce Results", e);
         }

--- a/src/test/java/com/saucelabs/saucerest/SauceRESTTest.java
+++ b/src/test/java/com/saucelabs/saucerest/SauceRESTTest.java
@@ -3,7 +3,6 @@ package com.saucelabs.saucerest;
 import org.apache.commons.lang.SerializationUtils;
 import org.hamcrest.CoreMatchers;
 import org.json.JSONObject;
-import org.json.simple.JSONValue;
 import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Rule;
@@ -208,7 +207,8 @@ public class SauceRESTTest {
         sauceREST.recordCI("jenkins", "1.1");
         assertEquals(this.urlConnection.getRealURL().getPath(), "/rest/v1/stats/ci");
         String output = this.urlConnection.getOutputStream().toString();
-        assertEquals(JSONValue.parse(output), JSONValue.parse("{\"platform_version\":\"1.1\",\"platform\":\"jenkins\"}"));
+        assertEquals(new JSONObject(output).toString(),
+            new JSONObject("{\"platform_version\":\"1.1\",\"platform\":\"jenkins\"}").toString());
     }
 
 
@@ -242,7 +242,7 @@ public class SauceRESTTest {
         assertEquals(this.urlConnection.getRealURL().getPath(), "/rest/v1/" + this.sauceREST.getUsername() + "/jobs/12345");
 
         String output = this.urlConnection.getOutputStream().toString();
-        assertEquals(JSONValue.parse(output), JSONValue.parse("{\"public\":\"shared\"}"));
+        assertEquals(output, "{\"public\":\"shared\"}");
     }
 
     @Test
@@ -403,7 +403,7 @@ public class SauceRESTTest {
         );
         assertNull(this.urlConnection.getRealURL().getQuery());
         String output = this.urlConnection.getOutputStream().toString();
-        assertEquals(JSONValue.parse(output), JSONValue.parse("{\"passed\":false}"));
+        assertEquals(output, "{\"passed\":false}");
     }
 
     @Test
@@ -418,7 +418,7 @@ public class SauceRESTTest {
         );
         assertNull(this.urlConnection.getRealURL().getQuery());
         String output = this.urlConnection.getOutputStream().toString();
-        assertEquals(JSONValue.parse(output), JSONValue.parse("{\"passed\":true}"));
+        assertEquals(output, "{\"passed\":true}");
     }
 
     @Test


### PR DESCRIPTION
`org.json:json` and `com.googlecode.json-simple:json-simple` are competing java libraries for JSON processing. There is no need to have both of them, only one is enough.