### PR TITLE
Fix dependencies: remove unused httpclient, add used commons-codec

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -55,9 +55,9 @@
     </distributionManagement>
     <dependencies>
         <dependency>
-            <groupId>org.apache.httpcomponents</groupId>
-            <artifactId>httpclient</artifactId>
-            <version>4.5.5</version>
+            <groupId>commons-codec</groupId>
+            <artifactId>commons-codec</artifactId>
+            <version>1.10</version>
         </dependency>
         <dependency>
             <groupId>org.json</groupId>


### PR DESCRIPTION
Declared dependency `org.apache.httpcomponents:httpclient` is not used explicily. But its transitive dependency `commons-codec:commons-codec` is used.