### PR TITLE
Adds MP4 support, replacing FLV

### DIFF
--- a/src/main/java/com/saucelabs/saucerest/SauceREST.java
+++ b/src/main/java/com/saucelabs/saucerest/SauceREST.java
@@ -252,7 +252,7 @@ public class SauceREST implements Serializable {
      * @param location represents the base directory where the video should be downloaded to
      */
     public void downloadVideo(String jobId, String location) {
-        URL restEndpoint = this.buildURL("v1/" + username + "/jobs/" + jobId + "/assets/video.flv");
+        URL restEndpoint = this.buildURL("v1/" + username + "/jobs/" + jobId + "/assets/video.mp4");
         saveFile(jobId, location, restEndpoint);
     }
 
@@ -267,7 +267,7 @@ public class SauceREST implements Serializable {
      */
 
     public BufferedInputStream downloadVideo(String jobId) throws IOException{
-        URL restEndpoint = this.buildURL("v1/" + username + "/jobs/" + jobId + "/assets/video.flv");
+        URL restEndpoint = this.buildURL("v1/" + username + "/jobs/" + jobId + "/assets/video.mp4");
         return downloadFileData(jobId, restEndpoint);
     }
 
@@ -328,7 +328,7 @@ public class SauceREST implements Serializable {
 
     /**
      * Downloads the HAR file for a Sauce Job, and returns it wrapped in a JSONTokener.
-     * 
+     *
      * Pass this JSONTokener to a JSONObject when you wish to read JSON.  The
      * stream will be read as soon as a JSONObject is created.
      *
@@ -504,13 +504,13 @@ public class SauceREST implements Serializable {
     private void saveFile(String jobId, String location, URL restEndpoint) {
         String jobAndAsset = restEndpoint.toString() + " for Job " + jobId;
         logger.log(Level.FINEST, "Attempting to save asset " + jobAndAsset + " to " + location);
-        
+
         try {
             BufferedInputStream in = downloadFileData(jobId, restEndpoint);
             SimpleDateFormat format = new SimpleDateFormat(DATE_FORMAT);
             String saveName = jobId + format.format(new Date());
-            if (restEndpoint.getPath().endsWith(".flv")) {
-                saveName = saveName + ".flv";
+            if (restEndpoint.getPath().endsWith(".mp4")) {
+                saveName = saveName + ".mp4";
             } else {
                 saveName = saveName + ".log";
             }

--- a/src/test/java/com/saucelabs/saucerest/SauceRESTTest.java
+++ b/src/test/java/com/saucelabs/saucerest/SauceRESTTest.java
@@ -385,7 +385,7 @@ public class SauceRESTTest {
 
         sauceREST.downloadVideo("1234", "location");
         assertEquals(
-            "/rest/v1/" + this.sauceREST.getUsername() + "/jobs/1234/assets/video.flv",
+            "/rest/v1/" + this.sauceREST.getUsername() + "/jobs/1234/assets/video.mp4",
             this.urlConnection.getRealURL().getPath()
         );
         assertNull(this.urlConnection.getRealURL().getQuery());


### PR DESCRIPTION
SauceLabs will be deprecating FLV support on June 10th, breaking FLV video downloads. This change replaces video request URLs to use the .mp4 extension instead of .flv.

https://wiki.saucelabs.com/display/DOCS/2018/05/23/Announcing+Flash+Deprecation+and+MP4+Beta+Support