### PR TITLE
add .har as extension when downloading HAR file

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,14 +51,14 @@ Assets are downloaded by providing a job ID and the location to save the asset t
 ### Selenium log
 
 ```java
-sauce.downloadLog("job_id", "/var/tmp/selenium.log");
+sauce.downloadLog("job_id", "/var/tmp/");
 ```
 
 ### HAR File
 HAR files are only available for jobs using [Extended Debugging](https://wiki.saucelabs.com/pages/viewpage.action?pageId=70072943).
 
 ```java
-sauce.downloadHAR("job_id", "/var/tmp/HAR.log");
+sauce.downloadHAR("job_id", "/var/tmp/");
 ```
 
 ### Video

--- a/src/main/java/com/saucelabs/saucerest/SauceREST.java
+++ b/src/main/java/com/saucelabs/saucerest/SauceREST.java
@@ -587,6 +587,8 @@ public class SauceREST implements Serializable {
             String saveName = jobId + format.format(new Date());
             if (restEndpoint.getPath().endsWith(".mp4")) {
                 saveName = saveName + ".mp4";
+            } else if (restEndpoint.getPath().endsWith(".har")) {
+                saveName = saveName + ".har";
             } else {
                 saveName = saveName + ".log";
             }

--- a/src/test/java/com/saucelabs/saucerest/SauceRESTTest.java
+++ b/src/test/java/com/saucelabs/saucerest/SauceRESTTest.java
@@ -15,6 +15,7 @@ import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
+import org.junit.rules.TemporaryFolder;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
@@ -31,6 +32,9 @@ import java.util.List;
 public class SauceRESTTest {
     @Rule
     public ExpectedException thrown = ExpectedException.none();
+
+    @Rule
+    public TemporaryFolder folder = new TemporaryFolder();
 
     private SauceREST sauceREST;
     private MockHttpURLConnection urlConnection;
@@ -379,14 +383,14 @@ public class SauceRESTTest {
         urlConnection.setResponseCode(200);
         urlConnection.setInputStream(new ByteArrayInputStream("{ }".getBytes("UTF-8")));
 
-        sauceREST.downloadLog("1234", "location");
+        sauceREST.downloadLog("1234", folder.getRoot().getAbsolutePath());
         assertEquals(
             "/rest/v1/" + this.sauceREST.getUsername() + "/jobs/1234/assets/selenium-server.log",
             this.urlConnection.getRealURL().getPath()
         );
         assertNull(this.urlConnection.getRealURL().getQuery());
 
-        sauceREST.downloadVideo("1234", "location");
+        sauceREST.downloadVideo("1234", folder.getRoot().getAbsolutePath());
         assertEquals(
             "/rest/v1/" + this.sauceREST.getUsername() + "/jobs/1234/assets/video.mp4",
             this.urlConnection.getRealURL().getPath()
@@ -399,7 +403,7 @@ public class SauceRESTTest {
         urlConnection.setResponseCode(200);
         urlConnection.setInputStream(new ByteArrayInputStream("{ }".getBytes("UTF-8")));
 
-        sauceREST.downloadHAR("1234", "location");
+        sauceREST.downloadHAR("1234", folder.getRoot().getAbsolutePath());
         assertEquals(
             "/v1/eds/1234/network.har",
             this.urlConnection.getRealURL().getPath()


### PR DESCRIPTION
Prior to this change, this was donwnloaded as a .log

This change adds a statement to check if it's a har file and sets the correct extension.
This also fixes some of our docs and tests that used the method incorrectly.