### PR TITLE
Add Asset fetch methods which raise Exceptions. Close #57.

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,10 +50,19 @@ Assets are downloaded by providing a job ID and the location to save the asset t
 
 Filenames are set automatically to `job_idyyyyMMdd_HHmmSS.ext`, where yyyyMMdd_HHmmSS is the retrieval timestamp and ext is determined by the asset type.
 
+Each of these methods comes in two flavours; the `downloadX` methods which ignore exceptions, and the `downloadXOrThrow` methods which throw:
+ * SauceException.NotAuthorized if credentials are missing or wrong
+ * FileNotFound if resources are missing or don't exist
+ * IOException if any of the many networking horrors which can occur, do
+
 ### Selenium log
 
 ```java
+// Download the log; Ignore exceptions
 sauce.downloadLog("job_id", "/var/tmp/");
+
+// Download the log; Raise SauceException.NotAuthorized, FileNotFound, IOException
+sauce.downloadLogOrThrow("job_id", "/var.tmp");
 ```
 
 Extension: `.log`
@@ -62,7 +71,11 @@ Extension: `.log`
 HAR files are only available for jobs using [Extended Debugging](https://wiki.saucelabs.com/pages/viewpage.action?pageId=70072943).
 
 ```java
+// Download the HAR file; Ignore exceptions
 sauce.downloadHAR("job_id", "/var/tmp/");
+
+// Download the HAR file; Raise SauceException.NotAuthorized, FileNotFound, IOException
+sauce.downloadHAROrThrow("job_id", "/var.tmp");
 ```
 
 Extension: `.har`
@@ -71,7 +84,11 @@ Extension: `.har`
 Video is only available for jobs which have not [disabled video recording](https://wiki.saucelabs.com/display/DOCS/Test+Configuration+Options#TestConfigurationOptions-Disablevideorecording).
 
 ```java
+// Download the Log; Ignore exceptions
 sauce.downloadVideo("job_id", "/var/tmp");
+
+// Download the Log; Raise SauceException.NotAuthorized, FileNotFound, IOException
+sauce.downloadVideoOrThrow("job_id", "/var/tmp");
 ```
 
 Extension: `.mp4`

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ Each of these methods comes in two flavours; the `downloadX` methods which ignor
 sauce.downloadLog("job_id", "/var/tmp/");
 
 // Download the log; Raise SauceException.NotAuthorized, FileNotFound, IOException
-sauce.downloadLogOrThrow("job_id", "/var.tmp");
+sauce.downloadLogOrThrow("job_id", "/var/tmp");
 ```
 
 Extension: `.log`
@@ -75,7 +75,7 @@ HAR files are only available for jobs using [Extended Debugging](https://wiki.sa
 sauce.downloadHAR("job_id", "/var/tmp/");
 
 // Download the HAR file; Raise SauceException.NotAuthorized, FileNotFound, IOException
-sauce.downloadHAROrThrow("job_id", "/var.tmp");
+sauce.downloadHAROrThrow("job_id", "/var/tmp");
 ```
 
 Extension: `.har`

--- a/pom.xml
+++ b/pom.xml
@@ -215,6 +215,14 @@
                     </execution>
                 </executions>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <source>8</source>
+                    <target>8</target>
+                </configuration>
+            </plugin>
         </plugins>
         <extensions>
             <extension>

--- a/src/main/java/com/saucelabs/saucerest/ErrorExplainers.java
+++ b/src/main/java/com/saucelabs/saucerest/ErrorExplainers.java
@@ -1,0 +1,49 @@
+package com.saucelabs.saucerest;
+
+/**
+ * A nice clean place to collect error messages intended to guide users when throwing exceptions.
+ */
+class ErrorExplainers {
+
+    static String missingCreds(){
+        return String.join(System.getProperty("line.separator"),
+            "If using System Properties/Environment Variables (ENVars), this can happen because:",
+            " * You are using a toolchain which does not automatically propagate ENVars between tools",
+            " * You are using a CI platform which does not automatically propagate ENVars between separate controller and processing hosts",
+            " * You are running tests on an environment on which these properties are not set; A newly build CI server, a Docker instance, etc"
+        );
+    }
+
+    static String incorrectCreds(String username, String accessKey){
+        String endOfKey = accessKey.substring(accessKey.length() - 3);
+
+        return String.join(System.getProperty("line.separator"),
+            "Not Authorized.  Possible Reasons:",
+            " * The provided Username (" + username +") is incorrect",
+            " * This account does not have permissions to access this job",
+            " * The provided Access Key ending with '" + endOfKey + "' is incorrect"
+        );
+    }
+
+    static String resourceMissing(){
+        return String.join(System.getProperty("line.separator"),
+            "Resource Not Found.   Possible reasons:",
+            " * This job does not exist",
+            " * Job assets have expired"
+        );
+    }
+
+    static String videoMissing(){
+        return String.join(System.getProperty("line.separator"),
+            " * You disabled video recording by setting the `recordVideo` capability to false",
+            " * This test was not able to complete video encoding due to an error or early termination"
+        );
+    }
+
+    public static String HARMissing(){
+        return String.join(System.getProperty("line.separator"),
+            " * This test was run without Extended Debugging. See https://wiki.saucelabs.com/pages/viewpage.action?pageId=70072943",
+            " * This test was not able to complete HAR file recording due to an error or early termination"
+        );
+    }
+}

--- a/src/main/java/com/saucelabs/saucerest/SauceException.java
+++ b/src/main/java/com/saucelabs/saucerest/SauceException.java
@@ -1,4 +1,7 @@
 package com.saucelabs.saucerest;
+/** @// TODO: 27/2/20 Lets have all these take a message, yeah?
+ * @// TODO: 27/2/20 And also, we should make these IOExceptions, not Runtime.
+ */
 
 /**
  * Created by gavinmogan on 11/2/15.
@@ -7,6 +10,24 @@ public class SauceException extends RuntimeException {
     /**
      * Created by gavinmogan on 11/2/15.
      */
-    public static class NotAuthorized extends SauceException { }
+    public SauceException(String message) {
+        super(message);
+    }
+
+    /**
+     * Default case.
+     */
+    public SauceException() {}
+
+    public static class NotAuthorized extends SauceException {
+
+        public NotAuthorized(String message) {
+            super(message);
+        }
+
+        public NotAuthorized(){
+
+        }
+    }
     public static class TooManyRequests extends SauceException { }
 }

--- a/src/test/java/com/saucelabs/saucerest/SauceRESTTest.java
+++ b/src/test/java/com/saucelabs/saucerest/SauceRESTTest.java
@@ -399,6 +399,34 @@ public class SauceRESTTest {
     }
 
     @Test
+    public void testDownloadWithFileNotFoundThrowsException() throws Exception {
+        urlConnection.setResponseCode(404);
+        thrown.expect(java.io.FileNotFoundException.class);
+        sauceREST.downloadLogOrThrow("1234", folder.getRoot().getAbsolutePath());
+    }
+
+    @Test
+    public void testDownloadLogWithWrongCredentialsThrowsException() throws Exception {
+        urlConnection.setResponseCode(401);
+        thrown.expect(SauceException.NotAuthorized.class);
+        sauceREST.downloadLogOrThrow("1234", folder.getRoot().getAbsolutePath());
+    }
+
+    @Test
+    public void testDownloadVideoWithFileNotFoundThrowsException() throws Exception {
+        urlConnection.setResponseCode(404);
+        thrown.expect(java.io.FileNotFoundException.class);
+        sauceREST.downloadVideoOrThrow("1234", folder.getRoot().getAbsolutePath());
+    }
+
+    @Test
+    public void testDownloadVideoWithWrongCredentialsThrowsException() throws Exception {
+        urlConnection.setResponseCode(401);
+        thrown.expect(SauceException.NotAuthorized.class);
+        sauceREST.downloadVideoOrThrow("1234", folder.getRoot().getAbsolutePath());
+    }
+
+    @Test
     public void testHARDownload() throws Exception {
         urlConnection.setResponseCode(200);
         urlConnection.setInputStream(new ByteArrayInputStream("{ }".getBytes("UTF-8")));
@@ -409,6 +437,20 @@ public class SauceRESTTest {
             this.urlConnection.getRealURL().getPath()
         );
         assertNull(this.urlConnection.getRealURL().getQuery());
+    }
+
+    @Test
+    public void testDownloadHARWithFileNotFoundThrowsException() throws Exception {
+        urlConnection.setResponseCode(404);
+        thrown.expect(java.io.FileNotFoundException.class);
+        sauceREST.downloadHAROrThrow("1234", folder.getRoot().getAbsolutePath());
+    }
+
+    @Test
+    public void testDownloadHARWithWrongCredentialsThrowsException() throws Exception {
+        urlConnection.setResponseCode(401);
+        thrown.expect(SauceException.NotAuthorized.class);
+        sauceREST.downloadHAROrThrow("1234", folder.getRoot().getAbsolutePath());
     }
 
     @Test


### PR DESCRIPTION
Currently, failures when fetching resources are transparent.  This is good when running tests as a REST API problem won't break a build, but it means that any
issues that occur go un-noticed.

This change adds `downloadXOrThrow` methods which raise either `SauceException.NotAuthorized`, `FileNotFound` or `IOException` when errors occur.