### PR TITLE
Return bools from downloadX

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,11 +55,12 @@ Each of these methods comes in two flavours; the `downloadX` methods which ignor
  * FileNotFound if resources are missing or don't exist
  * IOException if any of the many networking horrors which can occur, do
 
+The `downloadX` methods return a `boolean` indicating if the download was successful.
 ### Selenium log
 
 ```java
 // Download the log; Ignore exceptions
-sauce.downloadLog("job_id", "/var/tmp/");
+sauce.downloadLog("job_id", "/var/tmp/");  // => true if the Log downloads correctly
 
 // Download the log; Raise SauceException.NotAuthorized, FileNotFound, IOException
 sauce.downloadLogOrThrow("job_id", "/var.tmp");
@@ -72,7 +73,7 @@ HAR files are only available for jobs using [Extended Debugging](https://wiki.sa
 
 ```java
 // Download the HAR file; Ignore exceptions
-sauce.downloadHAR("job_id", "/var/tmp/");
+sauce.downloadHAR("job_id", "/var/tmp/"); // => true if the HAR File downloads correctly
 
 // Download the HAR file; Raise SauceException.NotAuthorized, FileNotFound, IOException
 sauce.downloadHAROrThrow("job_id", "/var.tmp");
@@ -85,7 +86,7 @@ Video is only available for jobs which have not [disabled video recording](https
 
 ```java
 // Download the Log; Ignore exceptions
-sauce.downloadVideo("job_id", "/var/tmp");
+sauce.downloadVideo("job_id", "/var/tmp"); // => true if the Video downloads correctly
 
 // Download the Log; Raise SauceException.NotAuthorized, FileNotFound, IOException
 sauce.downloadVideoOrThrow("job_id", "/var/tmp");

--- a/src/main/java/com/saucelabs/saucerest/SauceREST.java
+++ b/src/main/java/com/saucelabs/saucerest/SauceREST.java
@@ -319,12 +319,13 @@ public class SauceREST implements Serializable {
      *
      * If an IOException is encountered during operation, this method will fail _silently_.  Prefer {@link #downloadVideoOrThrow(String, String)}
      *
-     * @param jobId    the Sauce Job Id, typically equal to the Selenium/WebDriver sessionId
-     * @param location represents the base directory where the video should be downloaded to
+     * @param jobId     the Sauce Job Id, typically equal to the Selenium/WebDriver sessionId
+     * @param location  represents the base directory where the video should be downloaded to
+     * @return          True if the video was downloaded successfully; Otherwise false
      */
-    public void downloadVideo(String jobId, String location) {
+    public boolean downloadVideo(String jobId, String location) {
         URL restEndpoint = this.buildURL("v1/" + username + "/jobs/" + jobId + "/assets/video.mp4");
-        saveFile(jobId, location, restEndpoint);
+        return saveFile(jobId, location, restEndpoint);
     }
 
     /**
@@ -368,12 +369,13 @@ public class SauceREST implements Serializable {
      *
      * If an IOException is encountered during operation, this method will fail _silently_.  Prefer {@link #downloadLogOrThrow(String, String)}
      *
-     * @param jobId    the Sauce Job Id, typically equal to the Selenium/WebDriver sessionId
-     * @param location represents the base directory where the video should be downloaded to
+     * @param jobId     the Sauce Job Id, typically equal to the Selenium/WebDriver sessionId
+     * @param location  represents the base directory where the video should be downloaded to
+     * @return          True if the Log file downloads successfully; Otherwise false.
      */
-    public void downloadLog(String jobId, String location) {
+    public boolean downloadLog(String jobId, String location) {
         URL restEndpoint = this.buildURL("v1/" + username + "/jobs/" + jobId + "/assets/selenium-server.log");
-        saveFile(jobId, location, restEndpoint);
+        return saveFile(jobId, location, restEndpoint);
     }
 
     /**
@@ -415,12 +417,13 @@ public class SauceREST implements Serializable {
      *
      * If an IOException is encountered during operation, this method will fail _silently_.  Prefer {@link #downloadHAROrThrow(String, String)}
      *
-     * @param jobId    the Sauce Job Id, typically equal to the Selenium/WebDriver sessionId
-     * @param location represents the base directory where the HAR file should be downloaded to
+     * @param jobId     the Sauce Job Id, typically equal to the Selenium/WebDriver sessionId
+     * @param location  represents the base directory where the HAR file should be downloaded to
+     * @return          True if the HAR file downloads successfully, otherwise false
      */
-    public void downloadHAR(String jobId, String location) {
+    public boolean downloadHAR(String jobId, String location) {
         URL restEndpoint = this.buildEDSURL(jobId + "/network.har");
-        saveFile(jobId, location, restEndpoint);
+        return saveFile(jobId, location, restEndpoint);
     }
 
     /**
@@ -670,15 +673,18 @@ public class SauceREST implements Serializable {
      * If an IOException is thrown during this process, this method will fail _silently_ (although it will record the error
      * at Level.WARNING.  Use {@link #saveFileOrThrowException(String, String, URL)} to fail with an exception.
      *
-     * @param jobId        the Sauce Job id
-     * @param location     represents the location that the result file should be stored in
-     * @param restEndpoint the URL to perform a HTTP GET
+     * @param jobId         the Sauce Job id
+     * @param location      represents the location that the result file should be stored in
+     * @param restEndpoint  the URL to perform a HTTP GET
+     * @return              Whether the request successfully fetched a resource or not
      */
-    private void saveFile(String jobId, String location, URL restEndpoint) {
+    private boolean saveFile(String jobId, String location, URL restEndpoint) {
         try {
             saveFileOrThrowException(jobId, location, restEndpoint);
+            return true;
         } catch(IOException e) {
             logger.log(Level.WARNING, "Error downloading Sauce Results", e);
+            return false;
         }
     }
 

--- a/src/test/java/com/saucelabs/saucerest/SauceRESTTest.java
+++ b/src/test/java/com/saucelabs/saucerest/SauceRESTTest.java
@@ -2,10 +2,7 @@ package com.saucelabs.saucerest;
 
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.not;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertThat;
+import static org.junit.Assert.*;
 
 import org.apache.commons.lang.SerializationUtils;
 import org.hamcrest.CoreMatchers;
@@ -390,12 +387,13 @@ public class SauceRESTTest {
         );
         assertNull(this.urlConnection.getRealURL().getQuery());
 
-        sauceREST.downloadVideo("1234", folder.getRoot().getAbsolutePath());
+        boolean downloaded = sauceREST.downloadVideo("1234", folder.getRoot().getAbsolutePath());
         assertEquals(
             "/rest/v1/" + this.sauceREST.getUsername() + "/jobs/1234/assets/video.mp4",
             this.urlConnection.getRealURL().getPath()
         );
         assertNull(this.urlConnection.getRealURL().getQuery());
+        assertTrue(downloaded);
     }
 
     @Test
@@ -431,12 +429,13 @@ public class SauceRESTTest {
         urlConnection.setResponseCode(200);
         urlConnection.setInputStream(new ByteArrayInputStream("{ }".getBytes("UTF-8")));
 
-        sauceREST.downloadHAR("1234", folder.getRoot().getAbsolutePath());
+        boolean downloaded = sauceREST.downloadHAR("1234", folder.getRoot().getAbsolutePath());
         assertEquals(
             "/v1/eds/1234/network.har",
             this.urlConnection.getRealURL().getPath()
         );
         assertNull(this.urlConnection.getRealURL().getQuery());
+        assertTrue(downloaded);
     }
 
     @Test

--- a/src/test/java/com/saucelabs/saucerest/SauceRESTTest.java
+++ b/src/test/java/com/saucelabs/saucerest/SauceRESTTest.java
@@ -411,6 +411,20 @@ public class SauceRESTTest {
     }
 
     @Test
+    public void testVideoDownload() throws Exception {
+        urlConnection.setResponseCode(200);
+        urlConnection.setInputStream(new ByteArrayInputStream("{ }".getBytes("UTF-8")));
+
+        boolean downloaded = sauceREST.downloadVideo("1234", folder.getRoot().getAbsolutePath());
+        assertEquals(
+            "/rest/v1/fakeuser/jobs/1234/assets/video.mp4",
+            this.urlConnection.getRealURL().getPath()
+        );
+        assertNull(this.urlConnection.getRealURL().getQuery());
+        assertTrue(downloaded);
+    }
+
+    @Test
     public void testDownloadVideoWithFileNotFoundThrowsException() throws Exception {
         urlConnection.setResponseCode(404);
         thrown.expect(java.io.FileNotFoundException.class);


### PR DESCRIPTION
This change should be almost "drop in"; Users will be able to check the values of the returned methods to see if downloaded files were fetched successfully, but existing usecases will not change (as no-one is assigning things from methods which return void).