### PR TITLE
Deprecate `downloadX` methods, replacing with `attemptXDownload`.

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,11 +55,13 @@ Each of these methods comes in two flavours; the `downloadX` methods which ignor
  * FileNotFound if resources are missing or don't exist
  * IOException if any of the many networking horrors which can occur, do
 
+See (Asset Fetching)[https://github.com/DylanLacey/saucerest-java/wiki/Asset-Fetching] for more details.
+
 ### Selenium log
 
 ```java
 // Download the log; Ignore exceptions
-sauce.downloadLog("job_id", "/var/tmp/");
+sauce.attemptLogDownload("job_id", "/var/tmp/");
 
 // Download the log; Raise SauceException.NotAuthorized, FileNotFound, IOException
 sauce.downloadLogOrThrow("job_id", "/var/tmp");
@@ -72,7 +74,7 @@ HAR files are only available for jobs using [Extended Debugging](https://wiki.sa
 
 ```java
 // Download the HAR file; Ignore exceptions
-sauce.downloadHAR("job_id", "/var/tmp/");
+sauce.attemptHARDownload("job_id", "/var/tmp/");
 
 // Download the HAR file; Raise SauceException.NotAuthorized, FileNotFound, IOException
 sauce.downloadHAROrThrow("job_id", "/var/tmp");
@@ -85,7 +87,7 @@ Video is only available for jobs which have not [disabled video recording](https
 
 ```java
 // Download the Log; Ignore exceptions
-sauce.downloadVideo("job_id", "/var/tmp");
+sauce.attemptVideoDownload("job_id", "/var/tmp");
 
 // Download the Log; Raise SauceException.NotAuthorized, FileNotFound, IOException
 sauce.downloadVideoOrThrow("job_id", "/var/tmp");

--- a/src/main/java/com/saucelabs/saucerest/SauceREST.java
+++ b/src/main/java/com/saucelabs/saucerest/SauceREST.java
@@ -322,9 +322,27 @@ public class SauceREST implements Serializable {
      * @param jobId    the Sauce Job Id, typically equal to the Selenium/WebDriver sessionId
      * @param location represents the base directory where the video should be downloaded to
      */
-    public void downloadVideo(String jobId, String location) {
+    public void attemptVideoDownload(String jobId, String location) {
         URL restEndpoint = this.buildURL("v1/" + username + "/jobs/" + jobId + "/assets/video.mp4");
         saveFile(jobId, location, restEndpoint);
+    }
+
+    /**
+     * Downloads the video for a Sauce Job to the filesystem.  The file will be stored in a directory
+     * specified by the <code>location</code> field.
+     *
+     * Jobs are only available for jobs which finished without a Sauce side error, and for which the 'recordVideo' capability
+     * is not set to false.
+     *
+     * If an IOException is encountered during operation, this method will fail _silently_.  Prefer {@link #downloadVideoOrThrow(String, String)}
+     *
+     * @param jobId    the Sauce Job Id, typically equal to the Selenium/WebDriver sessionId
+     * @param location represents the base directory where the video should be downloaded to
+     * @deprecated  This method's behaviour will change in a future release to no longer swallow exceptions. To continue using the exception-swallowing version, please switch to {@link #attemptVideoDownload(String, String)}.
+     * @see https://github.com/DylanLacey/saucerest-java/wiki/Asset-Fetching
+     */
+    public void downloadVideo(String jobId, String location) {
+        downloadVideo(jobId, location);
     }
 
     /**
@@ -362,7 +380,6 @@ public class SauceREST implements Serializable {
     }
 
     /**
-     * @// TODO: 27/2/20 I think this should be called "attemptLogDownload" - Dylan
      * Downloads the log file for a Sauce Job to the filesystem.  The file will be stored in a
      * directory specified by the <code>location</code> field.
      *
@@ -371,9 +388,25 @@ public class SauceREST implements Serializable {
      * @param jobId    the Sauce Job Id, typically equal to the Selenium/WebDriver sessionId
      * @param location represents the base directory where the video should be downloaded to
      */
-    public void downloadLog(String jobId, String location) {
+    public void attemptLogDownload(String jobId, String location) {
         URL restEndpoint = this.buildURL("v1/" + username + "/jobs/" + jobId + "/assets/selenium-server.log");
         saveFile(jobId, location, restEndpoint);
+    }
+
+
+    /**
+     * Downloads the log file for a Sauce Job to the filesystem.  The file will be stored in a
+     * directory specified by the <code>location</code> field.
+     *
+     * If an IOException is encountered during operation, this method will fail _silently_.  Prefer {@link #downloadLogOrThrow(String, String)}
+     *
+     * @param jobId    the Sauce Job Id, typically equal to the Selenium/WebDriver sessionId
+     * @param location represents the base directory where the video should be downloaded to
+     * @deprecated  This method's behaviour will change in a future release to no longer swallow exceptions. To continue using the exception-swallowing version, please switch to {@link #attemptLogDownload(String, String)}.
+     * @see https://github.com/DylanLacey/saucerest-java/wiki/Asset-Fetching
+     */
+    public void downloadLog(String jobId, String location) {
+        downloadLog(jobId, location);
     }
 
     /**
@@ -406,7 +439,6 @@ public class SauceREST implements Serializable {
     }
 
     /**
-     * @// TODO: 27/2/20 I think this should be renamed "attemptHARDownload" - Dylan
      * Downloads the HAR file for a Sauce Job to the filesystem.  The file will be stored in a
      * directory specified by the <code>location</code> field.
      * <p>
@@ -418,9 +450,28 @@ public class SauceREST implements Serializable {
      * @param jobId    the Sauce Job Id, typically equal to the Selenium/WebDriver sessionId
      * @param location represents the base directory where the HAR file should be downloaded to
      */
-    public void downloadHAR(String jobId, String location) {
+    public void attemptHARDownload(String jobId, String location){
         URL restEndpoint = this.buildEDSURL(jobId + "/network.har");
         saveFile(jobId, location, restEndpoint);
+    }
+
+    /**
+     * Downloads the HAR file for a Sauce Job to the filesystem.  The file will be stored in a
+     * directory specified by the <code>location</code> field.
+     * <p>
+     * This will only work for jobs which support Extended Debugging, which were started with the
+     * 'extendedDebugging' capability set to true.
+     *
+     * If an IOException is encountered during operation, this method will fail _silently_.  Prefer {@link #downloadHAROrThrow(String, String)}
+     *
+     * @param jobId    the Sauce Job Id, typically equal to the Selenium/WebDriver sessionId
+     * @param location represents the base directory where the HAR file should be downloaded to
+     *
+     * @deprecated  This method's behaviour will change in a future release to no longer swallow exceptions. To continue using the exception-swallowing version, please switch to {@link #attemptHARDownload(String, String)}.
+     * @see https://github.com/DylanLacey/saucerest-java/wiki/Asset-Fetching
+     */
+    public void downloadHAR(String jobId, String location) {
+        downloadHAR(jobId, location);
     }
 
     /**

--- a/src/test/java/com/saucelabs/saucerest/SauceRESTTest.java
+++ b/src/test/java/com/saucelabs/saucerest/SauceRESTTest.java
@@ -379,18 +379,18 @@ public class SauceRESTTest {
     }
 
     @Test
-    public void testDownload() throws Exception {
+    public void testAttemptDownload() throws Exception {
         urlConnection.setResponseCode(200);
         urlConnection.setInputStream(new ByteArrayInputStream("{ }".getBytes("UTF-8")));
 
-        sauceREST.downloadLog("1234", folder.getRoot().getAbsolutePath());
+        sauceREST.attemptLogDownload("1234", folder.getRoot().getAbsolutePath());
         assertEquals(
             "/rest/v1/" + this.sauceREST.getUsername() + "/jobs/1234/assets/selenium-server.log",
             this.urlConnection.getRealURL().getPath()
         );
         assertNull(this.urlConnection.getRealURL().getQuery());
 
-        sauceREST.downloadVideo("1234", folder.getRoot().getAbsolutePath());
+        sauceREST.attemptVideoDownload("1234", folder.getRoot().getAbsolutePath());
         assertEquals(
             "/rest/v1/" + this.sauceREST.getUsername() + "/jobs/1234/assets/video.mp4",
             this.urlConnection.getRealURL().getPath()
@@ -427,11 +427,11 @@ public class SauceRESTTest {
     }
 
     @Test
-    public void testHARDownload() throws Exception {
+    public void testAttemptHARDownload() throws Exception {
         urlConnection.setResponseCode(200);
         urlConnection.setInputStream(new ByteArrayInputStream("{ }".getBytes("UTF-8")));
 
-        sauceREST.downloadHAR("1234", folder.getRoot().getAbsolutePath());
+        sauceREST.attemptHARDownload("1234", folder.getRoot().getAbsolutePath());
         assertEquals(
             "/v1/eds/1234/network.har",
             this.urlConnection.getRealURL().getPath()


### PR DESCRIPTION
Eventually, the `downloadX` methods will throw exceptions instead.  This has to
happen in several steps:

1. Alias them to `attemptXDownload`.
2. Mark them as Deprecated.
3. Remove them.
4. Rename the `downloadXOrThrow` methods to replace them.