### PR TITLE
Update maven-release-plugin to 3.0.0-M

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -145,7 +145,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-release-plugin</artifactId>
-                <version>2.5.3</version>
+                <version>3.0.0-M1</version>
                 <configuration>
                     <goals>deploy nexus-staging:release</goals>
                     <autoVersionSubmodules>true</autoVersionSubmodules>


### PR DESCRIPTION
The `maven-release-plugin` version was gettin' old and making Maven complain.  It's better now.

## How Has This Been Tested?
Ran `mvn test`.  Other changes are incoming to cut releases automagically.