### PR TITLE
Make conversion from String to DataCenter case-insensitive

### DIFF
--- a/src/main/java/com/saucelabs/saucerest/DataCenter.java
+++ b/src/main/java/com/saucelabs/saucerest/DataCenter.java
@@ -1,5 +1,7 @@
 package com.saucelabs.saucerest;
 
+import java.util.stream.Stream;
+
 public enum DataCenter {
     US("https://saucelabs.com/", "https://api.us-west-1.saucelabs.com/v1/eds/", "https://app.saucelabs.com/"),
     EU("https://eu-central-1.saucelabs.com/", "https://api.eu-central-1.saucelabs.com/v1/eds/", "https://app.eu-central-1.saucelabs.com/"),
@@ -27,11 +29,6 @@ public enum DataCenter {
     }
 
     public static DataCenter fromString(String dataCenter) {
-        for (DataCenter dc : DataCenter.values()) {
-            if (dc.name().equals(dataCenter)) {
-                return dc;
-            }
-        }
-        return US; // default to US
+        return Stream.of(values()).filter(dc -> dc.name().equalsIgnoreCase(dataCenter)).findFirst().orElse(US);
     }
 }

--- a/src/test/java/com/saucelabs/saucerest/DataCenterTests.java
+++ b/src/test/java/com/saucelabs/saucerest/DataCenterTests.java
@@ -1,0 +1,24 @@
+package com.saucelabs.saucerest;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+class DataCenterTests
+{
+    @CsvSource({
+        "US,      US",
+        "us,      US",
+        "EU,      EU",
+        "Eu,      EU",
+        "US_EAST, US_EAST",
+        "us_EaSt, US_EAST",
+        "unknown, US",
+    })
+    @ParameterizedTest
+    void testFromString(String input, DataCenter expected)
+    {
+        assertEquals(expected, DataCenter.fromString(input));
+    }
+}


### PR DESCRIPTION
## Description
Make conversion from String to DataCenter case-insensitive

## Motivation and Context
The input string in not UPPER case results in default data center: `US` (which may not match to the required one)

## How Has This Been Tested?
- unit-tests

## Types of changes
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (change which improves current code base; please describe the change)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist
- [x] I have read the [CONTRIBUTING](https://github.com/saucelabs/saucerest-java/blob/master/contributing.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All new and existing tests passed locally
- [ ] I have added necessary documentation (if appropriate)

