### PR TITLE
Make extraction of file extension generic

### DIFF
--- a/src/main/java/com/saucelabs/saucerest/SauceREST.java
+++ b/src/main/java/com/saucelabs/saucerest/SauceREST.java
@@ -828,10 +828,7 @@ public class SauceREST implements Serializable {
 
     private String getDefaultFileName(String jobId, URL restEndpoint) {
         SimpleDateFormat format = new SimpleDateFormat(DATE_FORMAT);
-        String saveName = jobId + format.format(new Date());
-        String extension = getExtension(restEndpoint);
-        saveName += extension;
-        return saveName;
+        return jobId + format.format(new Date()) + getExtension(restEndpoint);
     }
 
     private void saveFileOrThrowException(String jobId, String location, String fileName, URL restEndpoint) throws SauceException.NotAuthorized, IOException {
@@ -855,15 +852,9 @@ public class SauceREST implements Serializable {
     }
 
     private String getExtension(URL restEndpoint) {
-        if (restEndpoint.getPath().endsWith(".mp4")) {
-            return ".mp4";
-        } else if (restEndpoint.getPath().endsWith(".har")) {
-            return ".har";
-        } else if (restEndpoint.getPath().endsWith(".json")) {
-            return ".json";
-        } else {
-            return ".log";
-        }
+        String path = restEndpoint.getPath();
+        int indexOfDot = path.lastIndexOf('.');
+        return path.substring(indexOfDot);
     }
 
     /**


### PR DESCRIPTION
## Description
Make extraction of file extension independent of the actual data

## Motivation and Context
The new implementation is completely generic and allows to add support of other endpoints without necessity to change file extension logic.

## How Has This Been Tested?
The unit tests are improved.

## Types of changes
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Refactoring (change which improves current code base; please describe the change)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)


## Checklist
- [x] I have read the [CONTRIBUTING](https://github.com/saucelabs/saucerest-java/blob/master/contributing.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All new and existing tests passed locally
- [ ] I have added necessary documentation (if appropriate)
