### PR TITLE
Add release workflow.

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Set up JDK 1.8
         uses: actions/setup-java@v2
         with:
-          java-version: 8
+          java-version: 14
           #           gpg-private-key: ${{ secrets.GPG_PRIVATE_KEY }}
           #           gpg-passphrase: GPG_PASSPHRASE
           #           server-id: ossrh
@@ -45,7 +45,7 @@ jobs:
         uses: actions/setup-java@v2
         with:
           distribution: 'temurin'
-          java-version: 8
+          java-version: 14
           server-id: ossrh
           server-username: MAVEN_USERNAME
           server-password: MAVEN_CENTRAL_PASSWORD

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Set up JDK 1.8
         uses: actions/setup-java@v2
         with:
-          java-version: 14
+          java-version: 17
           #           gpg-private-key: ${{ secrets.GPG_PRIVATE_KEY }}
           #           gpg-passphrase: GPG_PASSPHRASE
           #           server-id: ossrh
@@ -45,7 +45,7 @@ jobs:
         uses: actions/setup-java@v2
         with:
           distribution: 'temurin'
-          java-version: 14
+          java-version: 17
           server-id: ossrh
           server-username: MAVEN_USERNAME
           server-password: MAVEN_CENTRAL_PASSWORD

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,44 +9,66 @@ on:
       releaseType:
         description: MAJOR, MINOR or PATCH release
         default: 'PATCH'
-      dry_run:
+      dryRun:
         description: Whether to perform a dry run instead of a full release.
-        default: false
+        default: true
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
   # This workflow contains a single job called "build"
   release:
     name: Preparing Build Environment
-    
+
     # The type of runner that the job will run on
     runs-on: ubuntu-latest
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
+      - name: "Log Run"
+        run: |
+          echo "$GITHUB_ACTOR requested ${{ github.event.inputs.releaseType }} release; Dry-run: ${{ github.event.inputs.dryRun }}"
       - name: Set up JDK 1.8
-        uses: actions/setup-java@v1.4.3
+        uses: actions/setup-java@v2
         with:
-          java-version: 1.8
-          gpg-private-key: ${{ secrets.GPG_PRIVATE_KEY }}
-      
-      - name: Install Maven
-        uses: aahmed-se/setup-maven@v3
-        with:
-          maven-version: 3.6.1
-      
+          java-version: 8
+          #           gpg-private-key: ${{ secrets.GPG_PRIVATE_KEY }}
+          #           gpg-passphrase: GPG_PASSPHRASE
+          #           server-id: ossrh
+          distribution: temurin
+
       - uses: actions/checkout@v2
 
       - name: Build & Test
         run: mvn -B test --file pom.xml
-        
+
+      - name: Set up Maven Central Config
+        uses: actions/setup-java@v2
+        with:
+          distribution: 'temurin'
+          java-version: 8
+          server-id: ossrh
+          server-username: MAVEN_USERNAME
+          server-password: MAVEN_CENTRAL_PASSWORD
+          gpg-private-key: ${{ secrets.GPG_PRIVATE_KEY }}
+          gpg-passphrase: gpg_passphrase
+
+      - name: Set up Git release
+        run: |
+          git config --global user.email "support@saucelabs.com"
+          git config --global user.name "Sauce Labs Publishbot"
+
       - name: Prepare Release
         env:
-          passphrase: ${{ secrets.GPG_PASSPHRASE }}
-        run: mvn -B release:clean release:prepare -DRELEASE_TYPE=$INPUT_RELEASETYPE -DdryRun=$INPUT_DRY_RUN
-      
+          gpg_passphrase: ${{ secrets.GPG_PASSPHRASE }}
+        run: |
+          git config --global user.email "support@saucelabs.com"
+          git config --global user.name "Sauce Labs Publishbot"
+          git remote set-url origin https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}
+          gpg --list-secret-keys
+          mvn -B release:clean release:prepare -DRELEASE_TYPE=${{ github.event.inputs.releaseType }} -DdryRun=${{ github.event.inputs.dryRun }} -Darguments=-Dgpg.passphrase=yErF44tnGyacIFFZ3ks$U%1Gm3bYIuHN -Dusername=${{ github.actor }} -X
+
       - name: Perform Release
-        if:  ${{ env.INPUT_DRY_RUN == false }} 
+        if:  ${{ github.event.inputs.releaseType == false }}
         env:
           ossrc-username: ${{ secrets.ossrc_username }}
           ossrc-password: ${{ secrets.ossrc_password }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -65,7 +65,7 @@ jobs:
           git config --global user.name "Sauce Labs Publishbot"
           git remote set-url origin https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}
           gpg --list-secret-keys
-          mvn -B release:clean release:prepare -DRELEASE_TYPE=${{ github.event.inputs.releaseType }} -DdryRun=${{ github.event.inputs.dryRun }} -Darguments=-Dgpg.passphrase=yErF44tnGyacIFFZ3ks$U%1Gm3bYIuHN -Dusername=${{ github.actor }} -X
+          mvn -B release:clean release:prepare -DRELEASE_TYPE=${{ github.event.inputs.releaseType }} -DdryRun=${{ github.event.inputs.dryRun }} -Dusername=${{ github.actor }} -X
 
       - name: Perform Release
         if:  ${{ github.event.inputs.releaseType == false }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -50,3 +50,30 @@ You can then update the pom file for your target project so that you're checking
 Get the value of the VERSION from the version key in the saucerest-java pom file.  ATM it's on line 6: `<version>1.0.38-SNAPSHOT</version>`.
 
 You may need to give it a custom version.
+
+# Releasing
+## Configuration
+Releases are done using the Github Action `Release to Maven Central`.  Github Secret Setup is required in advance:
+
+### Maven Credentials
+Configure `MAVEN_USERNAME` and `MAVEN_CENTRAL_PASSWORD` with credentials of a user with access to the com.saucelabs group
+
+### GPG Private Key
+GPG Private Key must be exported in ascii armor format and stored as `GPG_PRIVATE_KEY`.  The passphrase must be store in `GPG_PASSPHRASE`.
+
+## Performing a release -- Github Action
+1. Choose the "Release to Maven Central" workflow action
+2. Choose a releaseType -- This decides what version number will be incremented for this release
+3. Set `dryRun` to `false` to perform an actual release
+
+## Release Details
+### What Happens -- Always
+1. The library is built
+2. Tests run
+3. Maven advances the version number according to `releaseType` and removes `SNAPSHOT`, then packages
+4. Artifacts are GPG Signed
+
+### What Happens when not dry-run
+5. Code is tagged and committed
+6. Maven prepares for next release by advancing version number according to `releaseType` and appending `SNAPSHOT`
+7. Artifacts are released to Maven Central

--- a/pom.xml
+++ b/pom.xml
@@ -39,7 +39,7 @@
       <tag>saucerest-1.1.0</tag>
   </scm>
     <properties>
-        <java.version>14</java.version>
+        <java.version>17</java.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.sourceEncoding>UTF-8</project.reporting.sourceEncoding>
     </properties>

--- a/pom.xml
+++ b/pom.xml
@@ -39,7 +39,7 @@
       <tag>saucerest-1.1.0</tag>
   </scm>
     <properties>
-        <java.version>8</java.version>
+        <java.version>14</java.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.sourceEncoding>UTF-8</project.reporting.sourceEncoding>
     </properties>

--- a/pom.xml
+++ b/pom.xml
@@ -163,6 +163,7 @@
                     <useReleaseProfile>false</useReleaseProfile>
                     <releaseProfiles>release</releaseProfiles>
                     <goals>deploy</goals>
+                    <username>${env.RELEASEUSERNAME}</username>
                 </configuration>
                 <dependencies>
                     <dependency>
@@ -186,6 +187,13 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-gpg-plugin</artifactId>
                 <version>3.0.1</version>
+                <configuration>
+                    <!-- Prevent gpg from using pinentry programs -->
+                    <gpgArguments>
+                        <arg>--pinentry-mode=loopback</arg>
+                        <arg>--batch</arg>
+                    </gpgArguments>
+                </configuration>
                 <executions>
                     <execution>
                         <id>sign-artifacts</id>


### PR DESCRIPTION
## Description
New release workflow that should _actually_ work.

Requires some secret setup:

1. MAVEN_USERNAME
2. MAVEN_CENTRAL_PASSWORD

Release credentials for releasing user (Suggest we create a Sauce user for this)

3. GPG_PRIVATE_KEY
4. GPG_PASSPHRASE

GPG Credentials for signing release.  Again, suggest we create Sauce-specific creds.

To release, trigger the workflow manually and indicate what kind of release you wish to make.

## Motivation and Context
This allows us to release directly to Maven Central from Github

## How Has This Been Tested?
I've tested this action in my own fork (without performing a release) as well as performing releases with this pom setup on my local machine.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (change which improves current code base; please describe the change)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ x ] Documentation Update (if none of the other choices apply)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- This is simply a reminder of what we are going to look for before merging your code --->

- [ x ] I have read the [CONTRIBUTING](https://github.com/saucelabs/saucerest-java/blob/master/CONTRUBUTING.md) doc
- [ x ] I have added tests that prove my fix is effective or that my feature works
- [ x ] All new and existing tests passed locally
- [ x ] I have added necessary documentation (if appropriate)

## Further comments

We'll need to create the appropriate Maven Central user and GPG certificate for release.

I suggest we also include the GPG Public Key in the documentation so users can verify if concerned.