### PR TITLE
Use Java 8

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,7 @@
       <tag>HEAD</tag>
   </scm>
     <properties>
-        <java.version>17</java.version>
+        <java.version>8</java.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.sourceEncoding>UTF-8</project.reporting.sourceEncoding>
     </properties>


### PR DESCRIPTION
Projects (Jenkins Sauce OnDemand plugin) that depend on SauceREST need Java 8.

Fixes #231 