### PR TITLE
Use the latest version of the concurrency endpoint

### DIFF
--- a/src/main/java/com/saucelabs/saucerest/SauceREST.java
+++ b/src/main/java/com/saucelabs/saucerest/SauceREST.java
@@ -251,6 +251,10 @@ public class SauceREST implements Serializable {
         return buildEndpoint(apiServer, "v2/builds/" + source.name().toLowerCase(Locale.ROOT) + "/" + endpoint, "Builds URL");
     }
 
+    protected URL appendToBaseURL(String endpoint, String urlDescription) {
+        return buildEndpoint(apiServer, endpoint, urlDescription);
+    }
+
     private URL buildHarUrl(String jobId) {
         return this.buildEDSURL(jobId + "/" + TestAsset.HAR.label);
     }
@@ -1584,7 +1588,7 @@ public class SauceREST implements Serializable {
      * @return String (in JSON format) representing the concurrency information
      */
     public String getConcurrency() {
-        URL restEndpoint = buildURL("users/" + username + "/concurrency");
+        URL restEndpoint = appendToBaseURL("/rest/v1.2/users/" + username + "/concurrency", "Get User Concurrency");
         return retrieveResults(restEndpoint);
     }
 

--- a/src/test/java/com/saucelabs/saucerest/SauceRESTTest.java
+++ b/src/test/java/com/saucelabs/saucerest/SauceRESTTest.java
@@ -396,12 +396,13 @@ class SauceRESTTest {
     @Test
     void testGetConcurrency() throws Exception {
         urlConnection.setResponseCode(200);
-        urlConnection.setInputStream(getClass().getResource("/users_halkeye_concurrency.json").openStream());
-
-        String concurencyInfo = sauceREST.getConcurrency();
-        assertEquals(this.urlConnection.getRealURL().getPath(), "/rest/v1/users/" + this.sauceREST.getUsername() + "/concurrency");
+        urlConnection.setInputStream(getClass().getResource("/users_test_concurrency.json").openStream());
+        String concurrencyInfo = sauceREST.getConcurrency();
+        assertEquals("/rest/v1.2/users/" + this.sauceREST.getUsername() + "/concurrency", this.urlConnection.getRealURL().getPath());
         assertNull(this.urlConnection.getRealURL().getQuery());
-        assertEquals(concurencyInfo, "{\"timestamp\": 1447392030.111457, \"concurrency\": {\"halkeye\": {\"current\": {\"overall\": 0, \"mac\": 0, \"manual\": 0}, \"remaining\": {\"overall\": 100, \"mac\": 100, \"manual\": 5}}}}");
+
+        String expectedConcurrencyInfo = "{\"timestamp\":1447392030.111457,\"concurrency\":{\"organization\":{\"current\":{\"vms\":1,\"rds\":0,\"mac_vms\":0},\"id\":\"ca8b135d2e7e456385344811e05d84a6\",\"allowed\":{\"vms\":100,\"rds\":2,\"mac_vms\":100}},\"team\":{\"current\":{\"vms\":1,\"rds\":0,\"mac_vms\":0},\"id\":\"7e3beebb84bf4efaadffbbbbe780f294\",\"allowed\":{\"vms\":100,\"rds\":2,\"mac_vms\":100}}}}";
+        assertEquals(expectedConcurrencyInfo, concurrencyInfo);
     }
 
     @Test

--- a/src/test/resources/users_halkeye_concurrency.json
+++ b/src/test/resources/users_halkeye_concurrency.json
@@ -1,1 +1,0 @@
-{"timestamp": 1447392030.111457, "concurrency": {"halkeye": {"current": {"overall": 0, "mac": 0, "manual": 0}, "remaining": {"overall": 100, "mac": 100, "manual": 5}}}}

--- a/src/test/resources/users_test_concurrency.json
+++ b/src/test/resources/users_test_concurrency.json
@@ -1,0 +1,1 @@
+{"timestamp":1447392030.111457,"concurrency":{"organization":{"current":{"vms":1,"rds":0,"mac_vms":0},"id":"ca8b135d2e7e456385344811e05d84a6","allowed":{"vms":100,"rds":2,"mac_vms":100}},"team":{"current":{"vms":1,"rds":0,"mac_vms":0},"id":"7e3beebb84bf4efaadffbbbbe780f294","allowed":{"vms":100,"rds":2,"mac_vms":100}}}}


### PR DESCRIPTION
Use `/rest/v1.2/users/{username}/concurrency` endpoint to retrieve concurrency usage.

See https://docs.saucelabs.com/dev/api/accounts/#get-user-concurrency.
