### PR TITLE
Reduce scope of Selenium dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -82,11 +82,6 @@
             <version>2.4.4</version>
         </dependency>
         <dependency>
-            <groupId>org.seleniumhq.selenium</groupId>
-            <artifactId>selenium-java</artifactId>
-            <version>4.5.3</version>
-        </dependency>
-        <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter</artifactId>
             <version>5.9.1</version>
@@ -101,6 +96,12 @@
             <artifactId>lombok</artifactId>
             <version>1.18.24</version>
             <scope>compile</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.seleniumhq.selenium</groupId>
+            <artifactId>selenium-java</artifactId>
+            <version>4.5.3</version>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.commons</groupId>

--- a/src/main/java/com/saucelabs/saucerest/SauceREST.java
+++ b/src/main/java/com/saucelabs/saucerest/SauceREST.java
@@ -10,7 +10,6 @@ import org.apache.commons.io.IOUtils;
 import org.json.JSONException;
 import org.json.JSONObject;
 import org.json.JSONTokener;
-import org.openqa.selenium.remote.SessionId;
 import javax.net.ssl.HttpsURLConnection;
 import java.io.BufferedInputStream;
 import java.io.BufferedReader;
@@ -50,8 +49,6 @@ import java.util.concurrent.TimeUnit;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.stream.Stream;
-
-import static com.saucelabs.saucerest.DataCenter.US;
 
 /**
  * Simple Java API that invokes the Sauce REST API.  The full list of the Sauce REST API
@@ -186,10 +183,6 @@ public class SauceREST implements Serializable {
 
     public static void setExtraUserAgent(String extraUserAgent) {
         SauceREST.extraUserAgent = extraUserAgent;
-    }
-
-    public Job getJob(DataCenter dataCenter, SessionId sessionId) {
-        return getJob(dataCenter, sessionId.toString());
     }
 
     public Job getJob(DataCenter dataCenter, String sessionId) {

--- a/src/test/java/com/saucelabs/saucerest/integration/JobTest.java
+++ b/src/test/java/com/saucelabs/saucerest/integration/JobTest.java
@@ -71,9 +71,9 @@ public class JobTest {
         driver.set(new RemoteWebDriver(url, options));
 
         if (DataCenter.EU == param) {
-            job = new SauceREST(EU).getJob(EU, driver.get().getSessionId());
+            job = new SauceREST(EU).getJob(EU, driver.get().getSessionId().toString());
         } else if (DataCenter.USWEST == param) {
-            job = new SauceREST(US).getJob(US, driver.get().getSessionId());
+            job = new SauceREST(US).getJob(US, driver.get().getSessionId().toString());
         }
     }
 


### PR DESCRIPTION
Reduce scope of Selenium dependency

## Description
Only one class from Selenium is used as an input parameter, moreover `toString()` is invoked in this object and only String result is used after that. There is no much reason to import the full library. It's better to teach users to invoke `toString()` like it's done in the updated unit test.


## Motivation and Context
- Reduce the number of dependencies

## Types of changes

Since the new version is not released yet, it can be considered as a non-breaking change.

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (change which improves current code base; please describe the change)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Screenshots (if appropriate):

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- This is simply a reminder of what we are going to look for before merging your code --->

- [x] I have read the [CONTRIBUTING](https://github.com/saucelabs/saucerest-java/blob/master/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] All new and existing tests passed locally
- [ ] I have added necessary documentation (if appropriate)

