### PR TITLE
Add UnknownError exception, throw in deleteTunnel()

### DIFF
--- a/src/main/java/com/saucelabs/saucerest/SauceException.java
+++ b/src/main/java/com/saucelabs/saucerest/SauceException.java
@@ -22,6 +22,16 @@ public class SauceException extends RuntimeException {
     public SauceException() {
     }
 
+    public static class UnknownError extends SauceException {
+
+        public UnknownError(String message) {
+            super(message);
+        }
+
+        public UnknownError() {
+        }
+    }
+
     public static class NotAuthorized extends SauceException {
 
         public NotAuthorized(String message) {

--- a/src/main/java/com/saucelabs/saucerest/SauceREST.java
+++ b/src/main/java/com/saucelabs/saucerest/SauceREST.java
@@ -1475,12 +1475,17 @@ public class SauceREST implements Serializable {
         } catch (IOException e) {
             Throwable throwable = e.getCause();
 
-            if (throwable instanceof SauceException.NotAuthorized) {
+            if (throwable instanceof FileNotFoundException) {
+                throw (FileNotFoundException) throwable;
+            } else if (throwable instanceof IOException) {
+                throw (IOException) throwable;
+	    } else if (throwable instanceof SauceException.NotAuthorized) {
                 throw (SauceException.NotAuthorized) throwable;
             } else if (throwable instanceof SauceException.NotFound) {
                 throw (SauceException.NotFound) throwable;
-            }
-            logger.log(Level.WARNING, "Error deleting tunnel", e);
+            } else {
+                throw new SauceException.UnknownError("Unknown Error deleting tunnel");
+	    }
         }
 
         InputStream stream = connection.getInputStream();


### PR DESCRIPTION
## Description

Add an `UnknownError` exception, and throw that in `deleteTunnel()` if we have an unknown exception thrown when trying to delete the tunnel. Pass the `IOException` error if it's found first though.