### PR TITLE
Add testReportType to RDC DeviceJob

### DIFF
--- a/src/main/java/com/saucelabs/saucerest/model/realdevices/DeviceJob.java
+++ b/src/main/java/com/saucelabs/saucerest/model/realdevices/DeviceJob.java
@@ -86,11 +86,13 @@ public class DeviceJob {
     public String networkLogUrl;
     @Json(name = "testfairy_log_url")
     public String testfairyLogUrl;
+    @Json(name = "test_report_type")
+    public String testReportType;
 
     public DeviceJob() {
     }
 
-    public DeviceJob(ApplicationSummary applicationSummary, Object assignedTunnelId, String deviceType, String ownerSauce, String automationBackend, BaseConfig baseConfig, String build, Boolean collectsAutomatorLog, String consolidatedStatus, Long creationTime, DeviceDescriptor deviceDescriptor, Long endTime, Object error, String id, String frameworkLogUrl, String deviceLogUrl, String requestsUrl, Object testCasesUrl, Object junitLogUrl, Boolean manual, Long modificationTime, String name, String os, String osVersion, String deviceName, Boolean passed, Boolean proxied, Boolean recordScreenshots, List<Object> screenshots, Boolean recordVideo, Long startTime, String status, List<Object> tags, String videoUrl, String remoteAppFileUrl, String appiumSessionId, Object deviceSessionId, String client, String networkLogUrl, String testfairyLogUrl) {
+    public DeviceJob(ApplicationSummary applicationSummary, Object assignedTunnelId, String deviceType, String ownerSauce, String automationBackend, BaseConfig baseConfig, String build, Boolean collectsAutomatorLog, String consolidatedStatus, Long creationTime, DeviceDescriptor deviceDescriptor, Long endTime, Object error, String id, String frameworkLogUrl, String deviceLogUrl, String requestsUrl, Object testCasesUrl, Object junitLogUrl, Boolean manual, Long modificationTime, String name, String os, String osVersion, String deviceName, Boolean passed, Boolean proxied, Boolean recordScreenshots, List<Object> screenshots, Boolean recordVideo, Long startTime, String status, List<Object> tags, String videoUrl, String remoteAppFileUrl, String appiumSessionId, Object deviceSessionId, String client, String networkLogUrl, String testfairyLogUrl, String testReportType) {
         super();
         this.applicationSummary = applicationSummary;
         this.assignedTunnelId = assignedTunnelId;
@@ -132,5 +134,6 @@ public class DeviceJob {
         this.client = client;
         this.networkLogUrl = networkLogUrl;
         this.testfairyLogUrl = testfairyLogUrl;
+        this.testReportType = testReportType;
     }
 }


### PR DESCRIPTION
RDC recently added `test_report_type` to the Device Job responses, which was breaking the `RealDevicesTest.getSpecificDeviceJob` test.