### PR TITLE
Remove `mockito-inline` dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -133,11 +133,6 @@
       </dependency>
       <dependency>
         <groupId>org.mockito</groupId>
-        <artifactId>mockito-inline</artifactId>
-        <version>5.0.0</version>
-      </dependency>
-      <dependency>
-        <groupId>org.mockito</groupId>
         <artifactId>mockito-junit-jupiter</artifactId>
         <version>5.0.0</version>
         <scope>test</scope>


### PR DESCRIPTION
## Description
As of Mockito 5.0.0 the default mockmaker was switched to `mockito-inline`: https://github.com/mockito/mockito/releases/tag/v5.0.0.

More details and discussions: https://github.com/mockito/mockito/issues/2877.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (change which improves current code base; please describe the change)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Screenshots (if appropriate):

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- This is simply a reminder of what we are going to look for before merging your code --->

- [x] I have read the [CONTRIBUTING](https://github.com/saucelabs/saucerest-java/blob/master/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] All new and existing tests passed locally
- [ ] I have added necessary documentation (if appropriate)

