### PR TITLE
Fix parsing of response with Tunnels Information

### DIFF
--- a/src/main/java/com/saucelabs/saucerest/MoshiSingleton.java
+++ b/src/main/java/com/saucelabs/saucerest/MoshiSingleton.java
@@ -1,6 +1,13 @@
 package com.saucelabs.saucerest;
 
+import java.io.IOException;
+import java.math.BigInteger;
+
+import com.squareup.moshi.JsonAdapter;
+import com.squareup.moshi.JsonReader;
+import com.squareup.moshi.JsonWriter;
 import com.squareup.moshi.Moshi;
+import com.squareup.moshi.Moshi.Builder;
 
 public class MoshiSingleton {
 
@@ -11,7 +18,22 @@ public class MoshiSingleton {
 
     public static synchronized Moshi getInstance() {
         if (moshi == null) {
-            moshi = new Moshi.Builder().build();
+            moshi = new Builder()
+                .add(BigInteger.class, new JsonAdapter<BigInteger>()
+                {
+                    @Override
+                    public BigInteger fromJson(JsonReader jsonReader) throws IOException
+                    {
+                        return new BigInteger(jsonReader.nextString());
+                    }
+
+                    @Override
+                    public void toJson(JsonWriter jsonWriter, BigInteger bigInteger) throws IOException
+                    {
+                        jsonWriter.value(bigInteger.toString());
+                    }
+                })
+                .build();
         }
         return moshi;
     }

--- a/src/main/java/com/saucelabs/saucerest/model/sauceconnect/Metadata.java
+++ b/src/main/java/com/saucelabs/saucerest/model/sauceconnect/Metadata.java
@@ -1,5 +1,7 @@
 package com.saucelabs.saucerest.model.sauceconnect;
 
+import java.math.BigInteger;
+
 import com.squareup.moshi.Json;
 
 public class Metadata {
@@ -25,7 +27,7 @@ public class Metadata {
     @Json(name = "host_cpu")
     public String hostCpu;
     @Json(name = "nofile_limit")
-    public Integer nofileLimit;
+    public BigInteger nofileLimit;
 
     /**
      * No args constructor for use in serialization
@@ -46,7 +48,7 @@ public class Metadata {
      * @param platform
      * @param command
      */
-    public Metadata(String hostname, Long hostMemory, String commandArgs, String gitVersion, String platform, String command, String build, String externalProxy, String release, String hostCpu, Integer nofileLimit) {
+    public Metadata(String hostname, Long hostMemory, String commandArgs, String gitVersion, String platform, String command, String build, String externalProxy, String release, String hostCpu, BigInteger nofileLimit) {
         super();
         this.hostname = hostname;
         this.hostMemory = hostMemory;

--- a/src/test/java/com/saucelabs/saucerest/Helper.java
+++ b/src/test/java/com/saucelabs/saucerest/Helper.java
@@ -16,12 +16,12 @@ public class Helper {
      * @throws IOException if read fails for any reason
      * @see <a href="https://stackoverflow.com/a/46613809">https://stackoverflow.com/a/46613809</a>
      */
-    public String getResourceFileAsString(String fileName) throws IOException {
+    public static String getResourceFileAsString(String fileName) throws IOException {
         if (fileName == null || fileName.isEmpty()) {
             throw new IllegalArgumentException("File name cannot be null or empty.");
         }
 
-        try (InputStream is = Objects.requireNonNull(getClass().getResource(fileName), "File not found: " + fileName).openStream()) {
+        try (InputStream is = Objects.requireNonNull(Helper.class.getResource(fileName), "File not found: " + fileName).openStream()) {
 
             try (InputStreamReader isr = new InputStreamReader(is);
                  BufferedReader reader = new BufferedReader(isr)) {

--- a/src/test/java/com/saucelabs/saucerest/unit/AbstractEndpointTest.java
+++ b/src/test/java/com/saucelabs/saucerest/unit/AbstractEndpointTest.java
@@ -88,8 +88,7 @@ public class AbstractEndpointTest {
 
     @Test
     void testDeserializeJSONObjectWithListOfClassTypes_WithTwoItems() throws IOException {
-        Helper helper = new Helper();
-        String jsonResponse = helper.getResourceFileAsString("/buildsResponses.json");
+        String jsonResponse = Helper.getResourceFileAsString("/buildsResponses.json");
 
         List<Build> builds = new PersonEndpoint("").publicDeserializeJSONObject(jsonResponse, Collections.singletonList(Build.class));
 
@@ -98,8 +97,7 @@ public class AbstractEndpointTest {
 
     @Test
     void testDeserializeJSONObjectWithListOfClassTypes_WithOneItem() throws IOException {
-        Helper helper = new Helper();
-        String jsonResponse = helper.getResourceFileAsString("/buildsResponse.json");
+        String jsonResponse = Helper.getResourceFileAsString("/buildsResponse.json");
 
         List<Build> builds = new PersonEndpoint("").publicDeserializeJSONObject(jsonResponse, Collections.singletonList(Build.class));
 

--- a/src/test/java/com/saucelabs/saucerest/unit/HelperTest.java
+++ b/src/test/java/com/saucelabs/saucerest/unit/HelperTest.java
@@ -12,34 +12,30 @@ class HelperTest {
     @Test
     void testGetResourceFileAsStringWithValidFile() throws IOException {
         // Test for valid file
-        Helper helper = new Helper();
         String fileName = "/testfile.txt";
         String expectedContent = "This is a test file.\nIt has multiple lines.";
-        String actualContent = helper.getResourceFileAsString(fileName);
+        String actualContent = Helper.getResourceFileAsString(fileName);
         assertEquals(expectedContent, actualContent);
     }
 
     @Test
     void testGetResourceFileAsStringWithNonexistentFile() {
         // Test for nonexistent file
-        Helper helper = new Helper();
         String fileName = "/nonexistentfile.txt";
-        assertThrows(NullPointerException.class, () -> helper.getResourceFileAsString(fileName));
+        assertThrows(NullPointerException.class, () -> Helper.getResourceFileAsString(fileName));
     }
 
     @Test
     void testGetResourceFileAsStringWithNullFileName() {
         // Test for null file name
-        Helper helper = new Helper();
         String fileName = null;
-        assertThrows(IllegalArgumentException.class, () -> helper.getResourceFileAsString(fileName));
+        assertThrows(IllegalArgumentException.class, () -> Helper.getResourceFileAsString(fileName));
     }
 
     @Test
     void testGetResourceFileAsStringWithEmptyFileName() {
         // Test for empty file name
-        Helper helper = new Helper();
         String fileName = "";
-        assertThrows(IllegalArgumentException.class, () -> helper.getResourceFileAsString(fileName));
+        assertThrows(IllegalArgumentException.class, () -> Helper.getResourceFileAsString(fileName));
     }
 }

--- a/src/test/java/com/saucelabs/saucerest/unit/SauceConnectEndpointTest.java
+++ b/src/test/java/com/saucelabs/saucerest/unit/SauceConnectEndpointTest.java
@@ -1,0 +1,44 @@
+package com.saucelabs.saucerest.unit;
+
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.io.IOException;
+import java.util.List;
+
+import com.saucelabs.saucerest.DataCenter;
+import com.saucelabs.saucerest.Helper;
+import com.saucelabs.saucerest.HttpMethod;
+import com.saucelabs.saucerest.api.SauceConnectEndpoint;
+import com.saucelabs.saucerest.model.sauceconnect.TunnelInformation;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Spy;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import okhttp3.Response;
+import okhttp3.ResponseBody;
+
+@ExtendWith(MockitoExtension.class)
+class SauceConnectEndpointTest {
+
+    @Spy
+    private SauceConnectEndpoint sauceConnectEndpoint = new SauceConnectEndpoint("username", "access-key",
+        DataCenter.EU_CENTRAL);
+
+    @Test
+    void getTunnelsInformationForAUserTest() throws IOException {
+        Response response = mock();
+        ResponseBody responseBody = mock();
+        when(response.body()).thenReturn(responseBody);
+        when(responseBody.string()).thenReturn(Helper.getResourceFileAsString("/tunnelsResponse.json"));
+        doReturn(response).when(sauceConnectEndpoint).request(
+            "https://api.eu-central-1.saucelabs.com/rest/v1/username/tunnels?full=true", HttpMethod.GET);
+        List<TunnelInformation> tunnelsInfo = sauceConnectEndpoint.getTunnelsInformationForAUser();
+
+        Assertions.assertFalse(tunnelsInfo.isEmpty());
+    }
+}

--- a/src/test/resources/tunnelsResponse.json
+++ b/src/test/resources/tunnelsResponse.json
@@ -1,0 +1,46 @@
+[
+  {
+    "creation_time": 1717539836,
+    "direct_domains": null,
+    "domain_names": null,
+    "extra_info": "{\"runner\": \"false\", \"tunnel_cert\": \"public\", \"inject_job_id\": true, \"backend\": \"kgp\"}",
+    "host": "maki3763.eu-central-1.miso.saucelabs.com",
+    "id": "1aea0ee5dd7945d6bcdc016006de543a",
+    "ip_address": null,
+    "is_ready": true,
+    "last_connected": 1717539848,
+    "launch_time": 1717539846,
+    "metadata": {
+      "hostname": "fv-az731-352",
+      "host_memory": 17179398144,
+      "command_args": "{\"api-key\":\"****\",\"auth\":[],\"autodetect\":true,\"cainfo\":\"\",\"capath\":\"\",\"certificate\":\"\",\"config-file\":\"\",\"default-rest-url\":\"\",\"direct-domains\":[],\"dns\":[],\"doctor\":false,\"experimental\":[],\"ext\":\"127.0.0.1\",\"ext-port\":0,\"extra-info\":\"{\\\"runner\\\": \\\"false\\\"}\",\"fast-fail-regexps\":[],\"jobwaittimeout\":300,\"key\":\"\",\"kgp-handshake-timeout\":\"15s\",\"kgp-host\":\"\",\"kgp-hostname\":\"\",\"kgp-port\":443,\"log-stats\":\"0\",\"logfile\":\"\",\"max-logsize\":0,\"max-missed-acks\":300,\"metadata\":[],\"metrics-address\":\"\",\"no-autodetect\":false,\"no-cert-verify\":false,\"no-experimental\":false,\"no-http-cert-verify\":false,\"no-ocsp-verify\":false,\"no-proxy-caching\":false,\"no-remove-colliding-tunnels\":false,\"no-ssl-bump-domains\":[\"example.com\"],\"ocsp\":\"log-only\",\"output-config\":false,\"output-format\":\"pretty\",\"pac\":\"file:///C:\\\\Users\\\\RUNNER~1\\\\AppData\\\\Local\\\\Temp\\\\pac-saucelabs-98153760-7114-4eea-9a7b-c4048a20f2758181849572523160372.js\",\"pac-auth\":[],\"pidfile\":\"C:\\\\Users\\\\RUNNER~1\\\\AppData\\\\Local\\\\Temp\\\\sc_client-98153760-7114-4eea-9a7b-c4048a20f275-5957454500542236775.pid\",\"proxy\":\"\",\"proxy-localhost\":true,\"proxy-tunnel\":false,\"proxy-userpwd\":\"\",\"readyfile\":\"\",\"reconnect\":true,\"region\":\"\",\"rest-url\":\"https://api.eu-central-1.saucelabs.com/rest/v1\",\"scproxy-port\":0,\"scproxy-read-limit\":0,\"scproxy-write-limit\":0,\"se-port\":59428,\"server\":false,\"shared-tunnel\":false,\"start-timeout\":\"45s\",\"status-address\":\"\",\"tls-legacy\":false,\"tunnel-cainfo\":\"\",\"tunnel-capath\":\"\",\"tunnel-cert\":\"public\",\"tunnel-cert-suffix\":\"_maki12\",\"tunnel-domains\":[],\"tunnel-identifier\":\"\",\"tunnel-name\":\"98153760-7114-4eea-9a7b-c4048a20f275\",\"tunnel-pool\":true,\"user\":\"***\",\"verbose\":\"0\",\"vm-version\":\"\"}",
+      "git_version": "b491a8aa ",
+      "platform": "Windows_NT 6.2.9200  i386 25",
+      "command": "C:\\Users\\runneradmin\\sc-4.9.2-win32\\bin\\sc.exe -u *** -k **** -P 59428 --proxy-localhost --no-ssl-bump-domains example.com --tunnel-name 98153760-7114-4eea-9a7b-c4048a20f275 --pidfile C:\\Users\\RUNNER~1\\AppData\\Local\\Temp\\sc_client-98153760-7114-4eea-9a7b-c4048a20f275-5957454500542236775.pid --pac file:///C:\\Users\\RUNNER~1\\AppData\\Local\\Temp\\pac-saucelabs-98153760-7114-4eea-9a7b-c4048a20f2758181849572523160372.js --rest-url https://api.eu-central-1.saucelabs.com/rest/v1 --tunnel-pool --extra-info {\"runner\": \"false\"}",
+      "build": "2637",
+      "external_proxy": "{\"kgpProxy\":\"None\",\"restProxy\":\"PAC\"}",
+      "release": "4.9.2",
+      "host_cpu": "cpus:1,cores:4,model:AMD EPYC 7763 64-Core Processor                ",
+      "nofile_limit": 18446744073709551615
+    },
+    "no_proxy_caching": false,
+    "no_ssl_bump_domains": [
+      "example.com"
+    ],
+    "owner": "***",
+    "protocol": "kgp",
+    "shared_tunnel": false,
+    "shutdown_reason": null,
+    "shutdown_time": null,
+    "ssh_port": 443,
+    "status": "running",
+    "team_ids": [
+      "edd5e0dc2c724547b5b8b5b093c2a374"
+    ],
+    "tunnel_identifier": "98153760-7114-4eea-9a7b-c4048a20f275",
+    "use_caching_proxy": null,
+    "use_kgp": true,
+    "user_shutdown": null,
+    "vm_version": null
+  }
+]


### PR DESCRIPTION
Fixes #527.

## Description
Tunnels Information may contain value which more than Java Long.MAX_VALUE, that's why it's needed to use `BigInteger` instead of `int`.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (change which improves current code base; please describe the change)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Screenshots (if appropriate):

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- This is simply a reminder of what we are going to look for before merging your code --->

- [x] I have read the [CONTRIBUTING](https://github.com/saucelabs/saucerest-java/blob/master/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All new and existing tests passed locally
- [ ] I have added necessary documentation (if appropriate)

## Further comments
